### PR TITLE
Option to ban `echo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ parameters:
 	banned_code:
 		eval: true              # enable detection of `eval`
 		exit: true              # enable detection of `die/exit`
+		echo: true              # enable detection of `echo`
 		functions:              # banned functions
 			- debug_backtrace
 			- dump

--- a/src/Rules/BannedEchoRule.php
+++ b/src/Rules/BannedEchoRule.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the ekino/phpstan-banned-code project.
+ *
+ * (c) Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\PHPStanBannedCode\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Echo_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+/**
+ * @author Rémi Marseille <remi.marseille@ekino.com>
+ */
+class BannedEchoRule implements Rule
+{
+    /**
+     * @var bool
+     */
+    private $enabled;
+
+    /**
+     * @param bool $enabled
+     */
+    public function __construct(bool $enabled = true)
+    {
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeType(): string
+    {
+        return Echo_::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return $this->enabled ? ['Should not use "echo", please change the code.'] : [];
+    }
+}

--- a/tests/Rules/BannedEchoRuleTest.php
+++ b/tests/Rules/BannedEchoRuleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the ekino/phpstan-banned-code project.
+ *
+ * (c) Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Ekino\PHPStanBannedCode\Rules;
+
+use Ekino\PHPStanBannedCode\Rules\BannedEchoRule;
+use PhpParser\Node\Stmt\Echo_;
+use PHPStan\Analyser\Scope;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Rémi Marseille <remi.marseille@ekino.com>
+ */
+class BannedEchoRuleTest extends TestCase
+{
+    /**
+     * Tests getNodeType.
+     */
+    public function testGetNodeType()
+    {
+        $this->assertSame(Echo_::class, (new BannedEchoRule())->getNodeType());
+    }
+
+    /**
+     * Tests processNode.
+     */
+    public function testProcessNode()
+    {
+        $this->assertCount(0, (new BannedEchoRule(false))->processNode($this->createMock(Echo_::class), $this->createMock(Scope::class)));
+        $this->assertCount(1, (new BannedEchoRule())->processNode($this->createMock(Echo_::class), $this->createMock(Scope::class)));
+    }
+}


### PR DESCRIPTION
Fixes #3

When using PSR-7, you mustn't use echo in your application.