### PR TITLE
fix(bannedNodes): restrict the rule to named functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ master
 * Enable strict typing
 * Add coveralls and badges
 * Autoinstall through https://github.com/phpstan/extension-installer
+* Apply the BannedNodesRule only to named functions

--- a/src/Rules/BannedNodesRule.php
+++ b/src/Rules/BannedNodesRule.php
@@ -58,12 +58,8 @@ class BannedNodesRule implements Rule
         }
 
         if ($node instanceof FuncCall) {
-            if ($node->name instanceof Variable) {
-                return [];
-            }
-
             if (!$node->name instanceof Name) {
-                throw new \RuntimeException(sprintf('Expected instance of %s for $node->name, %s given', Name::class, \get_class($node->name)));
+                return [];
             }
 
             $function = $node->name->toString();

--- a/tests/Rules/BannedNodesRuleTest.php
+++ b/tests/Rules/BannedNodesRuleTest.php
@@ -22,6 +22,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Include_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
 use PHPStan\Analyser\Scope;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -93,6 +94,15 @@ class BannedNodesRuleTest extends TestCase
         }
 
         $node = new FuncCall(new Variable('myClosure'));
+
+        $this->assertCount(0, $this->rule->processNode($node, $this->scope));
+
+        $node = new FuncCall(
+            new Expr\ArrayDimFetch(
+                new Variable('myArray'),
+                LNumber::fromString('0', ['kind' => LNumber::KIND_DEC])
+            )
+        );
 
         $this->assertCount(0, $this->rule->processNode($node, $this->scope));
     }


### PR DESCRIPTION
The following cases of method calls were failing :
* $array\[$i\]()
* (new Item())()

Fixes #13