### PR TITLE
fix(tests): require dev nikic/parser explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 master
 ------
 
-* todo...
+* Fix tests by adding nikic/php-parser as a required dev dependency
 
 v0.3.0
 ------

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",
         "localheinz/composer-normalize": "^1.3",
+        "nikic/php-parser": "^4.3",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^7.2",
         "sensiolabs/security-checker": "^5.0",


### PR DESCRIPTION
Add nikic/parser as an explicit dev dependency in order classes used inside tests can be found.