### PR TITLE
Normalize leading backslashes in banned function names

### DIFF
--- a/src/Rules/BannedNodesRule.php
+++ b/src/Rules/BannedNodesRule.php
@@ -31,11 +31,17 @@ class BannedNodesRule implements Rule
     private $bannedNodes;
 
     /**
+     * @var array<string>
+     */
+    private $bannedFunctions;
+
+    /**
      * @param array<array<string, string|string[]>> $bannedNodes
      */
     public function __construct(array $bannedNodes)
     {
         $this->bannedNodes = array_column($bannedNodes, null, 'type');
+        $this->bannedFunctions = $this->normalizeFunctionNames($this->bannedNodes);
     }
 
     /**
@@ -64,7 +70,7 @@ class BannedNodesRule implements Rule
 
             $function = $node->name->toString();
 
-            if (\in_array($function, $this->bannedNodes[$type]['functions'])) {
+            if (\in_array($function, $this->bannedFunctions)) {
                 return [sprintf('Should not use function "%s", please change the code.', $function)];
             }
 
@@ -72,5 +78,27 @@ class BannedNodesRule implements Rule
         }
 
         return [sprintf('Should not use node with type "%s", please change the code.', $type)];
+    }
+
+    /**
+     * Strip leading slashes from function names.
+     *
+     * php-parser makes the same normalization.
+     *
+     * @param  array<string>  $bannedNodes
+     * @return array<string>
+     */
+    protected function normalizeFunctionNames(array $bannedNodes): array
+    {
+        if(! isset($bannedNodes['Expr_FuncCall']['functions'])) {
+            return [];
+        }
+
+        return array_map(
+            static function (string $function): string {
+                return ltrim($function, '\\');
+            },
+            $bannedNodes['Expr_FuncCall']['functions']
+        );
     }
 }


### PR DESCRIPTION
I stumbled upon this when trying to ban the use of `sprintf` in our project. Because we are using the amazing 

The configuration looks like this:

```neon
  banned_code:
    nodes:
    - type: Expr_FuncCall
      functions:
      - sprintf
      - \Safe\sprintf
```

What happened is that `\Safe\sprintf` was not found. Upon further investigation, i found that `php-parser` strips leading backslashes from function calls, even when they occur in the source code.

To avoid this hard to find error, i applied the same normalization to the banned functions definitions from the configuration file.