### PR TITLE
chore(dependencies): replaced deprecated composer normalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ master
 
 * Drop support for PHP 7.1
 * Added support of dd function
+* Replaced deprecated localheinz/composer-normalize in favor of ergebnis one
 
 v0.3.1
 ------

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "phpstan/phpstan": "^0.12"
     },
     "require-dev": {
+        "ergebnis/composer-normalize": "^2.6",
         "friendsofphp/php-cs-fixer": "^2.12",
-        "localheinz/composer-normalize": "^2.3",
         "nikic/php-parser": "^4.3",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.5",


### PR DESCRIPTION
Replacing abandonned composer normalizer https://packagist.org/packages/localheinz/composer-normalize in favor of https://packagist.org/packages/ergebnis/composer-normalize and upgrade to v2.6 minimum