### PR TITLE
Replace abandoned Sensiolabs security checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         "phpstan/phpstan": "^0.12"
     },
     "require-dev": {
+        "enlightn/security-checker": "^1.3",
         "ergebnis/composer-normalize": "^2.6",
         "friendsofphp/php-cs-fixer": "^2.17",
         "nikic/php-parser": "^4.3",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.5",
-        "enlightn/security-checker": "^1.3",
         "symfony/var-dumper": "^5.0"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nikic/php-parser": "^4.3",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.5",
-        "sensiolabs/security-checker": "^6.0",
+        "enlightn/security-checker": "^1.3",
         "symfony/var-dumper": "^5.0"
     },
     "extra": {


### PR DESCRIPTION
This PR replaces the deprecated [Sensiolabs security checker](https://github.com/sensiolabs/security-checker) with the [Enlightn security checker](https://github.com/enlightn/security-checker). It works in exactly the same manner, so there is no need to change Makefile, etc.