### PR TITLE
Updated PHPStan to v1 + PHPUnit to v9.

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0' ]
+        php: [ '7.3', '7.4', '8.0' ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP with tools

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /build/
 /vendor/
-/.php_cs.cache
+/.php-cs-fixer.cache
 /composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ master
 ------
 
 * Improve PHPStan configuration file
+* Updated to PHPStan 1.0
+* Updated to PHPUnit 9.5
 
 v0.5.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ master
 * Improve PHPStan configuration file
 * Updated to PHPStan 1.0
 * Updated to PHPUnit 9.5
+* Drop support for PHP 7.2
 
 v0.5.0
 ------

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "phpstan/phpstan": "^0.12"
+        "phpstan/phpstan": "^1.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.6",
         "friendsofphp/php-cs-fixer": "^3.0",
         "nikic/php-parser": "^4.3",
-        "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^8.5",
+        "phpstan/phpstan-phpunit": "^1.0",
+        "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.0"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "phpstan/phpstan": "^1.0"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
@@ -11,15 +11,17 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+        <report>
+            <clover outputFile="build/phpunit/clover.xml"/>
+            <html outputDirectory="build/phpunit/html"/>
+        </report>
+    </coverage>
 
     <logging>
-        <log type="coverage-clover" target="build/phpunit/clover.xml"/>
-        <log type="junit" target="build/phpunit/junit.xml"/>
-        <log type="coverage-html" target="build/phpunit/html"/>
+        <junit outputFile="build/phpunit/junit.xml"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
PHPStan 1.0 release announcement - https://phpstan.org/blog/phpstan-1-0-released

Breaking changes can be seen here - https://github.com/phpstan/phpstan/releases/tag/1.0.0

The PHP code for the extension seems fairly minimal and can't see any BC breakages myself. Tests/code quality tools passed and the detection of banned PHP functions/statements still worked when used in conjunction with PHPStan 1.0 in a test project.

I removed the ^0.12 constraint entirely since it doesn't seem overly important to me to maintain compatibility with the pre-1.0 PHPStan version. Users who can't upgrade PHPStan can remaing on an older version of this package and avoid having to maintain compatibility/test with multiple versions of PHPStan going forward for any changes made here. Let me know if you want it added back.

---

.php_cs.cache was renamed to .php-cs-fixer.cache in v3, see - https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/UPGRADE-v3.md#rename-of-files

---

Also upgraded PHPUnit to the latest version (similar to https://github.com/ekino/phpstan-banned-code/pull/41/files). Used the inbuilt migration feature to upgrade the configuration (`--migrate-configuration`) and updated to match current indentation/ordering as much as possible.

Changes to the PHPUnit config structure relate to: https://github.com/sebastianbergmann/phpunit/blob/9.3.11/ChangeLog-9.3.md#configuration-of-code-coverage-and-logging-in-phpunitxml

Without updating the configuration an additional warning is displayed in the output:

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

Please let me know if any changes are required to get these changes merged and released.