### PR TITLE
fix(rule): Fix phpstan fail for result of array_column

### DIFF
--- a/src/Rules/BannedNodesRule.php
+++ b/src/Rules/BannedNodesRule.php
@@ -26,12 +26,12 @@ use PHPStan\Rules\Rule;
 class BannedNodesRule implements Rule
 {
     /**
-     * @var array<array<string, string[]>>
+     * @var array<mixed>
      */
     private $bannedNodes;
 
     /**
-     * @param array<array<string, string|string[]>> $bannedNodes
+     * @param array<mixed> $bannedNodes
      */
     public function __construct(array $bannedNodes)
     {


### PR DESCRIPTION
Fixes the build error with the message

```
------ ----------------------------------------------------------------------- 
  Line   src/Rules/BannedNodesRule.php                                          
 ------ ----------------------------------------------------------------------- 
  38     Property Ekino\PHPStanBannedCode\Rules\BannedNodesRule::$bannedNodes   
         (array<array<string, array<string>>>) does not accept                  
         array<array<string>|int|string, array<string, array<string>|string>>.  
 ------ -----------------------------------------------------------------------
```

See https://github.com/ekino/phpstan-banned-code/runs/5225983073?check_suite_focus=true

This _might_ be linked to this change: https://github.com/phpstan/phpstan-src/pull/948