### PR TITLE
fix(ci): use sprintf native function

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.3', '7.4', '8.0' ]
+        php: [ '8.1', '8.2', '8.3' ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP with tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ CHANGELOG
 master
 ------
 
+* todo...
+
+v2.0.0
+------
+
+* Drop support for PHP ^7.3 || ^8.0, support now only ^8.1
+* Force usage of native sprintf function
 * Added rule to ban shell execution via backticks
 * Added rule to ban print statements
 * Allow Composer plugin ergebnis/composer-normalize

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "homepage": "https://github.com/ekino/phpstan-banned-code",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.1",
         "phpstan/phpstan": "^1.0"
     },
     "require-dev": {

--- a/src/Rules/BannedNodesRule.php
+++ b/src/Rules/BannedNodesRule.php
@@ -71,13 +71,13 @@ class BannedNodesRule implements Rule
             $function = $node->name->toString();
 
             if (\in_array($function, $this->bannedFunctions)) {
-                return [sprintf('Should not use function "%s", please change the code.', $function)];
+                return [\sprintf('Should not use function "%s", please change the code.', $function)];
             }
 
             return [];
         }
 
-        return [sprintf('Should not use node with type "%s", please change the code.', $type)];
+        return [\sprintf('Should not use node with type "%s", please change the code.', $type)];
     }
 
     /**

--- a/src/Rules/BannedUseTestRule.php
+++ b/src/Rules/BannedUseTestRule.php
@@ -62,14 +62,14 @@ class BannedUseTestRule implements Rule
         }
 
         if (!$node instanceof Use_) {
-            throw new \InvalidArgumentException(sprintf('$node must be an instance of %s, %s given', Use_::class, \get_class($node)));
+            throw new \InvalidArgumentException(\sprintf('$node must be an instance of %s, %s given', Use_::class, \get_class($node)));
         }
 
         $errors = [];
 
         foreach ($node->uses as $use) {
             if (preg_match('#^Tests#', $use->name->toString())) {
-                $errors[] = sprintf('Should not use %s in the non-test file %s', $use->name->toString(), $scope->getFile());
+                $errors[] = \sprintf('Should not use %s in the non-test file %s', $use->name->toString(), $scope->getFile());
             }
         }
 


### PR DESCRIPTION
force usage of native sprintf function to fix php-cs-fixer
Add php 8.1, 8.2, 8.3 support
Drop php support below 8.1