### PR TITLE
Add non-ignorable error handling feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ master
 
 * todo...
 
+v2.1.0
+------
+
+* Added option to prevent errors to be ignored
+* Added error identifiers starting with `ekinoBannedCode.`
+
 v2.0.0
 ------
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ parameters:
 
 		# enable detection of `use Tests\Foo\Bar` in a non-test file
 		use_from_tests: true
+
+		# errors emitted by the extension are non-ignorable by default, so they cannot accidentally be put into the baseline.
+		non_ignorable: false # default is true
 ```
 
 `type` is the returned value of a node, see the method `getType()`.

--- a/extension.neon
+++ b/extension.neon
@@ -5,6 +5,7 @@ parametersSchema:
 			functions: schema(listOf(string()), nullable())
 		]))
 		use_from_tests: bool()
+		non_ignorable: bool()
 	])
 
 parameters:
@@ -54,6 +55,9 @@ parameters:
 		# enable detection of `use Tests\Foo\Bar` in a non-test file
 		use_from_tests: true
 
+		# when true, errors cannot be excluded
+		non_ignorable: true
+
 services:
 	-
 		class: Ekino\PHPStanBannedCode\Rules\BannedNodesRule
@@ -68,3 +72,8 @@ services:
 			- phpstan.rules.rule
 		arguments:
 			- '%banned_code.use_from_tests%'
+
+	-
+		class: Ekino\PHPStanBannedCode\Rules\BannedNodesErrorBuilder
+		arguments:
+			- '%banned_code.non_ignorable%'

--- a/src/Rules/BannedNodesErrorBuilder.php
+++ b/src/Rules/BannedNodesErrorBuilder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the ekino/phpstan-banned-code project.
+ *
+ * (c) Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\PHPStanBannedCode\Rules;
+
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @author Rémi Marseille <remi.marseille@ekino.com>
+ */
+class BannedNodesErrorBuilder
+{
+    public const ERROR_IDENTIFIER_PREFIX = 'ekinoBannedCode';
+
+    public function __construct(private readonly bool $nonIgnorable)
+    {
+    }
+
+    public function buildError(
+        string $errorMessage,
+        string $errorSuffix
+    ): RuleError {
+        $errBuilder = RuleErrorBuilder::message($errorMessage)
+            ->identifier(\sprintf('%s.%s', self::ERROR_IDENTIFIER_PREFIX, $errorSuffix));
+
+        if ($this->nonIgnorable) {
+            $errBuilder->nonIgnorable();
+        }
+
+        return $errBuilder->build();
+    }
+}

--- a/src/Rules/BannedUseTestRule.php
+++ b/src/Rules/BannedUseTestRule.php
@@ -23,17 +23,11 @@ use PHPStan\Rules\Rule;
  */
 class BannedUseTestRule implements Rule
 {
-    /**
-     * @var bool
-     */
-    private $enabled;
-
-    /**
-     * @param bool $enabled
-     */
-    public function __construct(bool $enabled = true)
+    public function __construct(
+        private readonly bool $enabled,
+        private readonly BannedNodesErrorBuilder $errorBuilder
+    )
     {
-        $this->enabled = $enabled;
     }
 
     /**
@@ -69,7 +63,10 @@ class BannedUseTestRule implements Rule
 
         foreach ($node->uses as $use) {
             if (preg_match('#^Tests#', $use->name->toString())) {
-                $errors[] = \sprintf('Should not use %s in the non-test file %s', $use->name->toString(), $scope->getFile());
+                $errors[] = $this->errorBuilder->buildError(
+                    \sprintf('Should not use %s in the non-test file %s', $use->name->toString(), $scope->getFile()),
+                    'test',
+                );
             }
         }
 


### PR DESCRIPTION
Proposal for #65.
Instead of returning a list of strings, the extension now returns a RuleError object built using the [RuleErrorBuilder](https://phpstan.org/blog/using-rule-error-builder).

Note that I am not familiar with PHPStan extension development and this PR is a very first attempt to solve the issue I created.

Please note that this PR also [sets identifiers](https://phpstan.org/blog/using-rule-error-builder#error-identifiers) to the errors. They are namely:

* `bannedcode.function`
* `bannedcode.expression`
* `bannedcode.test`

Let me know if these IDs are suitable or if you prefer to define others.