### PR TITLE
feat(dependency): handle PHPStan v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "homepage": "https://github.com/ekino/phpstan-banned-code",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.0"
+        "phpstan/phpstan": "^1.0 || ^2.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.6",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "nikic/php-parser": "^4.3",
-        "phpstan/phpstan-phpunit": "^1.0",
+        "nikic/php-parser": "^4.3 || ^5.3",
+        "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.0"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,8 +4,6 @@ parameters:
 		- src
 		- tests
 
-	checkGenericClassInNonGenericObjectType: false
-
 includes:
 	- extension.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon

--- a/tests/Rules/BannedNodesRuleTest.php
+++ b/tests/Rules/BannedNodesRuleTest.php
@@ -62,8 +62,7 @@ class BannedNodesRuleTest extends TestCase
                 ['type' => 'Expr_FuncCall', 'functions' => ['debug_backtrace', 'dump', 'Safe\namespaced']],
                 ['type' => 'Expr_Print'],
                 ['type' => 'Expr_ShellExec'],
-            ],
-            new BannedNodesErrorBuilder(true)
+            ]
         );
         $this->scope = $this->createMock(Scope::class);
     }
@@ -99,8 +98,7 @@ class BannedNodesRuleTest extends TestCase
                         'Safe\namespaced',
                     ]
                 ],
-            ],
-            new BannedNodesErrorBuilder(true)
+            ]
         );
 
         $ruleWithLeadingSlashes = new BannedNodesRule(
@@ -112,8 +110,7 @@ class BannedNodesRuleTest extends TestCase
                         '\Safe\namespaced',
                     ]
                 ],
-            ],
-            new BannedNodesErrorBuilder(true)
+            ]
         );
 
         $rootFunction = new FuncCall(new Name('root'));
@@ -130,8 +127,6 @@ class BannedNodesRuleTest extends TestCase
         $errors = $rule->processNode($node, $this->scope);
         $this->assertCount(1, $errors);
         $error = $errors[0];
-        $this->assertInstanceOf(RuleError::class, $error);
-        $this->assertInstanceOf(IdentifierRuleError::class, $error);
         $this->assertStringStartsWith('ekinoBannedCode.', $error->getIdentifier());
         $this->assertInstanceOf(NonIgnorableRuleError::class, $error);
     }
@@ -197,6 +192,6 @@ class BannedNodesRuleTest extends TestCase
         yield [new Eval_($this->createMock(Expr::class))];
         yield [new Exit_()];
         yield [new Print_($this->createMock(Expr::class))];
-        yield [new ShellExec([''])];
+        yield [new ShellExec([$this->createMock(Expr::class)])];
     }
 }

--- a/tests/Rules/BannedUseTestRuleTest.php
+++ b/tests/Rules/BannedUseTestRuleTest.php
@@ -46,10 +46,7 @@ class BannedUseTestRuleTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->rule  = new BannedUseTestRule(
-            true,
-            new BannedNodesErrorBuilder(true)
-        );
+        $this->rule  = new BannedUseTestRule(true);
         $this->scope = $this->createMock(Scope::class);
     }
 
@@ -67,10 +64,7 @@ class BannedUseTestRuleTest extends TestCase
     public function testProcessNodeIfDisabled(): void
     {
         $this->scope->expects($this->never())->method('getNamespace');
-        $testRule = new BannedUseTestRule(
-            false,
-            new BannedNodesErrorBuilder(true)
-        );
+        $testRule = new BannedUseTestRule(false);
 
         $this->assertCount(0, ($testRule)->processNode($this->createMock(Use_::class), $this->scope));
     }
@@ -83,17 +77,6 @@ class BannedUseTestRuleTest extends TestCase
         $this->scope->expects($this->once())->method('getNamespace')->willReturn('Tests\\Foo\\Bar');
 
         $this->assertCount(0, $this->rule->processNode($this->createMock(Use_::class), $this->scope));
-    }
-
-    /**
-     * Asserts processNode throws an exception with invalid argument.
-     */
-    public function testProcessNodeThrowsException(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->scope->expects($this->once())->method('getNamespace')->willReturn('Foo\\Bar');
-
-        $this->rule->processNode($this->createMock(Node::class), $this->scope);
     }
 
     /**
@@ -111,8 +94,6 @@ class BannedUseTestRuleTest extends TestCase
         $errors = $this->rule->processNode($node, $this->scope);
         $this->assertCount(1, $errors);
         $error = $errors[0];
-        $this->assertInstanceOf(RuleError::class, $error);
-        $this->assertInstanceOf(IdentifierRuleError::class, $error);
         $this->assertStringStartsWith('ekinoBannedCode.', $error->getIdentifier());
         $this->assertInstanceOf(NonIgnorableRuleError::class, $error);
     }


### PR DESCRIPTION
Here is an update of the library to allow the usage of PHPStan v2.
This pull request was creating mainly by following this upgrade recommendation : https://phpstan.org/blog/using-rule-error-builder.
The new defined identifiers are inspired from : https://phpstan.org/error-identifiers but with keeping the prefix "ekinoBannedCode"
Note : The pull request may require to create a new tag.
