### PR TITLE
chore(dependencies): update phpunit/phpunit to 10.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build/
 /vendor/
+/var/
+/.phpunit.cache/
 /.php-cs-fixer.cache
 /composer.lock
-/.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ master
 * Replace `fabpot/local-php-security-checker` by `composer audit` for the security check
 * Move code snippets into tests directory
 * Updated nikic/php-parser to 5.4
+* Updated phpunit/phpunit to 10.5
 
+v3.0.0
 ------
 
 * Updated to PHPStan 2.0

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ app-static-analysis: ## to run static analysis
 	vendor/bin/phpstan analyze --memory-limit=-1
 
 app-test: ## to run unit tests
-	vendor/bin/phpunit
+	vendor/bin/phpunit --no-coverage
 
 app-test-functional: ## test some code snippets are detected as banned code
 	@for filename in $$(find tests/Functional/snippets -type f -name *.php); do \
@@ -39,6 +39,7 @@ app-test-functional: ## test some code snippets are detected as banned code
 	done \
 
 app-test-with-code-coverage: ## to run unit tests with code-coverage
+	@php -m | grep -qE 'xdebug|pcov' || (echo "Please install Xdebug or PCOV to enable code coverage." && exit 1)
 	vendor/bin/phpunit --coverage-text --colors=never
 
 ci: ## to run checks during ci

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "nikic/php-parser": "^5.4",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.5",
         "symfony/var-dumper": "^5.0"
     },
     "minimum-stability": "dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
+         cacheDirectory=".phpunit.cache">
 
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-        <report>
-            <clover outputFile="build/phpunit/clover.xml"/>
-            <html outputDirectory="build/phpunit/html"/>
-        </report>
-    </coverage>
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
 
-    <logging>
-        <junit outputFile="build/phpunit/junit.xml"/>
-    </logging>
+  <coverage>
+    <report>
+      <clover outputFile="build/phpunit/clover.xml"/>
+      <html outputDirectory="build/phpunit/html"/>
+    </report>
+  </coverage>
+
+  <logging>
+    <junit outputFile="build/phpunit/junit.xml"/>
+  </logging>
+
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/Unit/Rules/BannedUseTestRuleTest.php
+++ b/tests/Unit/Rules/BannedUseTestRuleTest.php
@@ -31,15 +31,8 @@ use PHPUnit\Framework\TestCase;
  */
 class BannedUseTestRuleTest extends TestCase
 {
-    /**
-     * @var BannedUseTestRule
-     */
-    private $rule;
-
-    /**
-     * @var Scope|MockObject
-     */
-    private $scope;
+    private BannedUseTestRule $rule;
+    private Scope&MockObject $scope;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
- From v10, phpunit requires xdebug or pcov for code coverage, so when running 'app-test-with-code-coverage' locally we now need to install one of them. No changes are required to the CI as it's supported out of the box with shivammathur/setup-php (https://github.com/shivammathur/setup-php?tab=readme-ov-file#signal_strength-coverage-support)

- From v11 phpunit requires PHP >=8.2, so we are locked on phpunit 10 until we drop support of PHP 8.1. (https://packagist.org/packages/phpunit/phpunit#11.0.0)
