### PR TITLE
chore(dependencies): update symfony/var-dumper to 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ master
 * Move code snippets into tests directory
 * Updated nikic/php-parser to 5.4
 * Updated phpunit/phpunit to 10.5
+* Updated symfony/var-dumper to 6.4
 
 v3.0.0
 ------

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nikic/php-parser": "^5.4",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^10.5",
-        "symfony/var-dumper": "^5.0"
+        "symfony/var-dumper": "^6.4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
- From v7 var-dumper requires PHP >=8.2, so we are locked on v6 until we drop support of PHP 8.1. (https://packagist.org/packages/symfony/var-dumper#v7.0.0)

