### PR TITLE
chore(ci): add php 8.4

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.1', '8.2', '8.3' ]
+        php: [ '8.1', '8.2', '8.3', '8.4' ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP with tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ master
 * Updated phpunit/phpunit to 10.5
 * Updated symfony/var-dumper to 6.4
 * Added empty() to the list of banned functions
+* Added PHP 8.4 to the CI run
 
 v3.0.0
 ------

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ app-composer-validate: ## to validate composer config
 	composer normalize --dry-run
 
 app-cs-check: ## to show files that need to be fixed
-	vendor/bin/php-cs-fixer fix --dry-run --diff --verbose
+	PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff --verbose
 
 app-cs-fix: ## to fix files that need to be fixed
 	vendor/bin/php-cs-fixer fix --verbose


### PR DESCRIPTION
Added PHP_CS_FIXER_IGNORE_ENV to 'app-cs-check' to let cs-fixer run on PHP 8.4 correctly, otherwise it throws an error. 

It's still under discussion here - https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8300 whether the 'ignore env' should be passed as a config parameter or this error removed completely for PHP 8.4.