### PR TITLE
update regex for test namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ master
 * Updated symfony/var-dumper to 6.4
 * Added empty() to the list of banned functions
 * Added PHP 8.4 to the CI run
-
-v3.1.0
-------
-
 * Added support for nested namespaces for tests in `BannedUseTestRule`
 
 v3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ master
 * Added empty() to the list of banned functions
 * Added PHP 8.4 to the CI run
 
+v3.1.0
+------
+
+* Added support for nested namespaces for tests in `BannedUseTestRule`
+
 v3.0.0
 ------
 

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "homepage": "https://github.com/ekino/phpstan-banned-code",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^2.0"
+        "phpstan/phpstan": "^1.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.6",
         "friendsofphp/php-cs-fixer": "^3.0",
         "nikic/php-parser": "^5.4",
-        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^10.5",
         "symfony/var-dumper": "^6.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "homepage": "https://github.com/ekino/phpstan-banned-code",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.0"
+        "phpstan/phpstan": "^2.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.6",
         "friendsofphp/php-cs-fixer": "^3.0",
         "nikic/php-parser": "^5.4",
-        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^10.5",
         "symfony/var-dumper": "^6.4"
     },

--- a/src/Rules/BannedUseTestRule.php
+++ b/src/Rules/BannedUseTestRule.php
@@ -25,7 +25,8 @@ class BannedUseTestRule implements Rule
 {
     public function __construct(
         private readonly bool $enabled,
-        private readonly BannedNodesErrorBuilder $errorBuilder
+        private readonly BannedNodesErrorBuilder $errorBuilder,
+        private readonly string $pattern = '(^|\\\\)Tests($|\\\\)'
     )
     {
     }
@@ -51,7 +52,7 @@ class BannedUseTestRule implements Rule
             return [];
         }
 
-        if (preg_match('#(^Tests\\\\|\\\\Tests\\\\|\\\\Tests$|^Tests$)#', $namespace)) {
+        if (preg_match("#{$this->pattern}#", $namespace)) {
             return [];
         }
 
@@ -62,7 +63,7 @@ class BannedUseTestRule implements Rule
         $errors = [];
 
         foreach ($node->uses as $use) {
-            if (preg_match('#(^Tests\\\\|\\\\Tests\\\\|\\\\Tests$|^Tests$)#', $use->name->toString())) {
+            if (preg_match("#{$this->pattern}#", $use->name->toString())) {
                 $errors[] = $this->errorBuilder->buildError(
                     \sprintf('Should not use %s in the non-test file %s', $use->name->toString(), $scope->getFile()),
                     'test',

--- a/src/Rules/BannedUseTestRule.php
+++ b/src/Rules/BannedUseTestRule.php
@@ -51,7 +51,7 @@ class BannedUseTestRule implements Rule
             return [];
         }
 
-        if (preg_match('#^Tests#', $namespace)) {
+        if (preg_match('#(^Tests\\\\|\\\\Tests\\\\|\\\\Tests$|^Tests$)#', $namespace)) {
             return [];
         }
 
@@ -62,7 +62,7 @@ class BannedUseTestRule implements Rule
         $errors = [];
 
         foreach ($node->uses as $use) {
-            if (preg_match('#^Tests#', $use->name->toString())) {
+            if (preg_match('#(^Tests\\\\|\\\\Tests\\\\|\\\\Tests$|^Tests$)#', $use->name->toString())) {
                 $errors[] = $this->errorBuilder->buildError(
                     \sprintf('Should not use %s in the non-test file %s', $use->name->toString(), $scope->getFile()),
                     'test',

--- a/tests/Unit/Rules/BannedUseTestRuleTest.php
+++ b/tests/Unit/Rules/BannedUseTestRuleTest.php
@@ -90,7 +90,7 @@ class BannedUseTestRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{string}>
+     * @return iterable<string, list<string>>
      */
     public static function namespaceDataProvider(): iterable
     {
@@ -102,6 +102,7 @@ class BannedUseTestRuleTest extends TestCase
 
     /**
      * @dataProvider errorCasesDataProvider
+     * @param list<string> $useStatements
      */
     public function testProcessNodeWithErrors(
         string $namespace,

--- a/tests/Unit/Rules/BannedUseTestRuleTest.php
+++ b/tests/Unit/Rules/BannedUseTestRuleTest.php
@@ -69,16 +69,6 @@ class BannedUseTestRuleTest extends TestCase
     }
 
     /**
-     * Tests processNode with test scope.
-     */
-    public function testProcessNodeWithTestScope(): void
-    {
-        $this->scope->expects($this->once())->method('getNamespace')->willReturn('Tests\\Foo\\Bar');
-
-        $this->assertCount(0, $this->rule->processNode($this->createMock(Use_::class), $this->scope));
-    }
-
-    /**
      * Asserts processNode throws an exception with invalid argument.
      */
     public function testProcessNodeThrowsException(): void
@@ -90,60 +80,42 @@ class BannedUseTestRuleTest extends TestCase
     }
 
     /**
-     * Tests processNode with errors.
+     * @dataProvider testNamespaceDataProvider
      */
-    public function testProcessNodeWithErrors(): void
+    public function testProcessNodeWithTestNamespaces(string $namespace): void
     {
-        $this->scope->expects($this->once())->method('getNamespace')->willReturn('Foo\\Bar');
-
-        $node = new Use_([
-            new UseUse(new Name('Foo\\Bar')),
-            new UseUse(new Name('Tests\\Foo\\Bar')),
-        ]);
-
-        $errors = $this->rule->processNode($node, $this->scope);
-        $this->assertCount(1, $errors);
-        $error = $errors[0];
-        $this->assertStringStartsWith('ekinoBannedCode.', $error->getIdentifier());
-        $this->assertInstanceOf(NonIgnorableRuleError::class, $error);
-    }
-
-    /**
-     * Tests processNode with nested test namespaces - Modules\Foo\Tests.
-     */
-    public function testProcessNodeWithNestedTestNamespace(): void
-    {
-        $this->scope->expects($this->once())->method('getNamespace')->willReturn('Modules\\Foo\\Tests');
+        $this->scope->expects($this->once())->method('getNamespace')->willReturn($namespace);
 
         $this->assertCount(0, $this->rule->processNode($this->createMock(Use_::class), $this->scope));
     }
 
     /**
-     * Tests processNode with deeply nested test namespaces - Modules\Foo\Tests\Models\State.
+     * @return iterable<string, array{string}>
      */
-    public function testProcessNodeWithDeeplyNestedTestNamespace(): void
+    public static function testNamespaceDataProvider(): iterable
     {
-        $this->scope->expects($this->once())->method('getNamespace')->willReturn('Modules\\Foo\\Tests\\Models\\State');
-
-        $this->assertCount(0, $this->rule->processNode($this->createMock(Use_::class), $this->scope));
+        yield 'Tests namespace prefix' => ['Tests\\Foo\\Bar'];
+        yield 'Nested test namespace' => ['Modules\\Foo\\Tests'];
+        yield 'Deeply nested test namespace' => ['Modules\\Foo\\Tests\\Models\\State'];
+        yield 'Trailing Tests segment' => ['App\\Module\\Tests'];
     }
 
     /**
-     * Tests processNode detects banned use statements for nested test classes.
+     * @dataProvider errorCasesDataProvider
      */
-    public function testProcessNodeWithErrorsForNestedTestClasses(): void
-    {
-        $this->scope->expects($this->once())->method('getNamespace')->willReturn('App\\Services');
+    public function testProcessNodeWithErrors(
+        string $namespace,
+        array $useStatements,
+        int $expectedErrorCount
+    ): void {
+        $this->scope->expects($this->once())->method('getNamespace')->willReturn($namespace);
 
-        $node = new Use_([
-            new UseUse(new Name('App\\Models\\User')),
-            new UseUse(new Name('Modules\\Foo\\Tests\\SomeTestHelper')),
-            new UseUse(new Name('Modules\\Bar\\Tests\\Models\\A')),
-        ]);
+        $uses = array_map(fn($use) => new UseUse(new Name($use)), $useStatements);
+        $node = new Use_($uses);
 
         $errors = $this->rule->processNode($node, $this->scope);
-        $this->assertCount(2, $errors);
-        
+        $this->assertCount($expectedErrorCount, $errors);
+
         foreach ($errors as $error) {
             $this->assertStringStartsWith('ekinoBannedCode.', $error->getIdentifier());
             $this->assertInstanceOf(NonIgnorableRuleError::class, $error);
@@ -151,28 +123,26 @@ class BannedUseTestRuleTest extends TestCase
     }
 
     /**
-     * Tests processNode with trailing Tests namespace segment.
+     * @return iterable<string, array{string, array<string>, int}>
      */
-    public function testProcessNodeWithTrailingTestsSegment(): void
+    public static function errorCasesDataProvider(): iterable
     {
-        $this->scope->expects($this->once())->method('getNamespace')->willReturn('App\\Module\\Tests');
+        yield 'Basic test import detection' => [
+            'Foo\\Bar',
+            ['Foo\\Bar', 'Tests\\Foo\\Bar'],
+            1
+        ];
 
-        $this->assertCount(0, $this->rule->processNode($this->createMock(Use_::class), $this->scope));
-    }
+        yield 'Multiple nested test imports' => [
+            'App\\Services',
+            ['App\\Models\\User', 'Modules\\Foo\\Tests\\SomeTestHelper', 'Modules\\Bar\\Tests\\Models\\A'],
+            2
+        ];
 
-    /**
-     * Tests processNode does not match partial 'Tests' strings.
-     */
-    public function testProcessNodeDoesNotMatchPartialTests(): void
-    {
-        $this->scope->expects($this->once())->method('getNamespace')->willReturn('App\\SomeTestsRelated\\Service');
-
-        $node = new Use_([
-            new UseUse(new Name('App\\SomeTestsRelated\\Model')),
-            new UseUse(new Name('App\\NotTestsButSimilar\\Helper')),
-        ]);
-
-        $errors = $this->rule->processNode($node, $this->scope);
-        $this->assertCount(0, $errors);
+        yield 'No test-related imports' => [
+            'App\\SomeTestsRelated\\Service',
+            ['App\\SomeTestsRelated\\Model', 'App\\NotTestsButSimilar\\Helper'],
+            0
+        ];
     }
 }

--- a/tests/Unit/Rules/BannedUseTestRuleTest.php
+++ b/tests/Unit/Rules/BannedUseTestRuleTest.php
@@ -92,7 +92,7 @@ class BannedUseTestRuleTest extends TestCase
     /**
      * @return iterable<string, array{string}>
      */
-    public static function testNamespaceDataProvider(): iterable
+    public static function namespaceDataProvider(): iterable
     {
         yield 'Tests namespace prefix' => ['Tests\\Foo\\Bar'];
         yield 'Nested test namespace' => ['Modules\\Foo\\Tests'];

--- a/tests/Unit/Rules/BannedUseTestRuleTest.php
+++ b/tests/Unit/Rules/BannedUseTestRuleTest.php
@@ -107,4 +107,72 @@ class BannedUseTestRuleTest extends TestCase
         $this->assertStringStartsWith('ekinoBannedCode.', $error->getIdentifier());
         $this->assertInstanceOf(NonIgnorableRuleError::class, $error);
     }
+
+    /**
+     * Tests processNode with nested test namespaces - Modules\Foo\Tests.
+     */
+    public function testProcessNodeWithNestedTestNamespace(): void
+    {
+        $this->scope->expects($this->once())->method('getNamespace')->willReturn('Modules\\Foo\\Tests');
+
+        $this->assertCount(0, $this->rule->processNode($this->createMock(Use_::class), $this->scope));
+    }
+
+    /**
+     * Tests processNode with deeply nested test namespaces - Modules\Foo\Tests\Models\State.
+     */
+    public function testProcessNodeWithDeeplyNestedTestNamespace(): void
+    {
+        $this->scope->expects($this->once())->method('getNamespace')->willReturn('Modules\\Foo\\Tests\\Models\\State');
+
+        $this->assertCount(0, $this->rule->processNode($this->createMock(Use_::class), $this->scope));
+    }
+
+    /**
+     * Tests processNode detects banned use statements for nested test classes.
+     */
+    public function testProcessNodeWithErrorsForNestedTestClasses(): void
+    {
+        $this->scope->expects($this->once())->method('getNamespace')->willReturn('App\\Services');
+
+        $node = new Use_([
+            new UseUse(new Name('App\\Models\\User')),
+            new UseUse(new Name('Modules\\Foo\\Tests\\SomeTestHelper')),
+            new UseUse(new Name('Modules\\Bar\\Tests\\Models\\A')),
+        ]);
+
+        $errors = $this->rule->processNode($node, $this->scope);
+        $this->assertCount(2, $errors);
+        
+        foreach ($errors as $error) {
+            $this->assertStringStartsWith('ekinoBannedCode.', $error->getIdentifier());
+            $this->assertInstanceOf(NonIgnorableRuleError::class, $error);
+        }
+    }
+
+    /**
+     * Tests processNode with trailing Tests namespace segment.
+     */
+    public function testProcessNodeWithTrailingTestsSegment(): void
+    {
+        $this->scope->expects($this->once())->method('getNamespace')->willReturn('App\\Module\\Tests');
+
+        $this->assertCount(0, $this->rule->processNode($this->createMock(Use_::class), $this->scope));
+    }
+
+    /**
+     * Tests processNode does not match partial 'Tests' strings.
+     */
+    public function testProcessNodeDoesNotMatchPartialTests(): void
+    {
+        $this->scope->expects($this->once())->method('getNamespace')->willReturn('App\\SomeTestsRelated\\Service');
+
+        $node = new Use_([
+            new UseUse(new Name('App\\SomeTestsRelated\\Model')),
+            new UseUse(new Name('App\\NotTestsButSimilar\\Helper')),
+        ]);
+
+        $errors = $this->rule->processNode($node, $this->scope);
+        $this->assertCount(0, $errors);
+    }
 }

--- a/tests/Unit/Rules/BannedUseTestRuleTest.php
+++ b/tests/Unit/Rules/BannedUseTestRuleTest.php
@@ -80,7 +80,7 @@ class BannedUseTestRuleTest extends TestCase
     }
 
     /**
-     * @dataProvider testNamespaceDataProvider
+     * @dataProvider namespaceDataProvider
      */
     public function testProcessNodeWithTestNamespaces(string $namespace): void
     {


### PR DESCRIPTION
**Summary**

This PR fixes #59.
It improves the BannedUseTestRule to correctly detect and exclude nested test namespaces used in modular PHP applications.

**Problem**
Previously, the rule only matched namespaces starting with Tests\ (e.g., Tests\Unit\SomeTest), failing to handle valid patterns like:

```
Modules\Foo\Tests
Modules\Foo\Tests\Models\State
Modules\Bar\Tests\Models\A
```

As a result, test namespaces within modules were incorrectly processed and flagged as violations.

**Solution**

Updated the regex pattern from ^Tests to:

`(^Tests\\|\\Tests\\|\\Tests$|^Tests$)`

**New pattern covers:**

`^Tests\\` → root-level tests (backward compatible)
`\\Tests\\` → nested test namespaces
`\\Tests$` → trailing test segments
`^Tests$` → exact Tests namespace