### PR TITLE
chore(PHP-CS): rename 'visibility_required' to 'modifier_keywords' in…

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -65,7 +65,7 @@ return $config->setRules([
     'phpdoc_add_missing_param_annotation' => true,
     'phpdoc_order' => true,
     'semicolon_after_instruction' => true,
-    'visibility_required' => [
+    'modifier_keywords' => [
         'elements' => ['method', 'property', 'const']
     ],
 ])

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ app-install: ## to install app
 	composer install --prefer-dist
 
 app-security-check: ## to check if any security issues in the PHP dependencies
-	composer audit
+	composer audit --abandoned=report
 
 app-static-analysis: ## to run static analysis
 	vendor/bin/phpstan analyze --memory-limit=-1


### PR DESCRIPTION
Hello,

As you can see, the `visibility_required` rule is now deprecated.

This PR fixes the issue by replacing it with the new `modifier_keywords` rule.
I also fixed an error message caused by an abandoned package while waiting for the end of support for PHP 8.2.